### PR TITLE
Add symbolic names of messages to the output

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -155,7 +155,7 @@ class PocketLinter(object):
 
     @property
     def _pylint_args(self):
-        args = [ "--msg-template='{msg_id}:{line:3d},{column}: {obj}: {msg}'",
+        args = [ "--msg-template='{msg_id}({symbol}):{line:3d},{column}: {obj}: {msg}'",
                  "-r", "n",
                  "--disable", "C,R",
                  "--rcfile", "/dev/null",


### PR DESCRIPTION
Symbolic names are used for disabling in comments and are thus useful to get/know.
