### PR TITLE
Clean up some new pylint warnings about type vs. isinstance

### DIFF
--- a/pocketlint/checkers/markup.py
+++ b/pocketlint/checkers/markup.py
@@ -111,7 +111,7 @@ class MarkupChecker(BaseChecker):
 
     @check_messages("invalid-markup", "invalid-markup-element", "unescaped-markup", "invalid-translated-markup", "invalid-translated-markup-element", "invalid-pango-translation", "unnecessary-markup")
     def visit_const(self, node):
-        if type(node.value) not in (str, bytes):
+        if not isinstance(node.value, (str, bytes)):
             return
 
         if not is_markup(node.value):

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -154,6 +154,8 @@ class PointlessAssignment(PointlessData):
 
     @classmethod
     def check_equal(cls, node, other):
+        # Allow the type() checks so that only an exact match will pass
+        # pylint: disable=unidiomatic-typecheck
         if type(node) != type(other):
             return False
         if isinstance(node, astroid.Const):

--- a/pocketlint/pangocheck.py
+++ b/pocketlint/pangocheck.py
@@ -28,7 +28,7 @@ markup_nodes = ["markup", "a", "b", "big", "i", "s", "span", "sub", "sup", "smal
 
 # Check to see if a string looks like Pango markup, no validation
 def is_markup(test_string):
-    if type(test_string) == bytes:
+    if isinstance(test_string, bytes):
         test_string = test_string.decode("utf-8")
 
     return any(re.search(r'<\s*%s(\s|>)' % node_type, test_string)


### PR DESCRIPTION
Leave the type() checks in pointless-override.py, I think it is better
to have them as exact checks.
