### PR TITLE
E1103 is hiding common errors

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -56,7 +56,6 @@ class PocketLintConfig(object):
                  "W0613",           # Unused argument %r
                  "W0614",           # Unused import %s from wildcard import
                  "E0012",           # Bad inline option given to pylint
-                 "E1103",           # %s %r has no %r member (but some types could not be inferred)
                  "I0011",           # Locally disabling %s
                  "I0012",           # Locally enabling %s
                  "I0013",           # Ignoring entire file


### PR DESCRIPTION
IIRC it was originally there because of the gi.repository introspection
bug in pylint, which is now fixed.

%s %r has no %r member should now either be valid, or overridden in the
%per-project pocketlint setup.
