### PR TITLE
Fallback to using pylint in case we didn't install from RPM

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -276,7 +276,11 @@ class PocketLinter(object):
         return retval
 
     def _run_one(self, filename, args):
-        proc = subprocess.Popen(["python3-pylint"] + self._pylint_args + args + [filename],
+        pylint_exe = "/usr/bin/python3-pylint"
+        # in case we've installed pylint from pip, not rpm
+        if not os.path.exists(pylint_exe):
+            pylint_exe="pylint"
+        proc = subprocess.Popen([pylint_exe] + self._pylint_args + args + [filename],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()
         output = stdout + stderr


### PR DESCRIPTION
I'm trying to use pocketlint inside a virtualenv (also Travis-CI) and without this patch it fails b/c there isn't a python3-pylint command. 

NB: there's a possibility for confusion at the moment, b/c "pylint" will default to "/usr/bin/pylint" if we're not inside a virtualenv and that will blow up b/c it's Python2. At the moment I'm not sure how to cleanly resolve this or even if we want to.
