### PR TITLE
Fix pylint name for Fedora 26 and later

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -276,10 +276,12 @@ class PocketLinter(object):
         return retval
 
     def _run_one(self, filename, args):
-        pylint_exe = "/usr/bin/python3-pylint"
-        # in case we've installed pylint from pip, not rpm
-        if not os.path.exists(pylint_exe):
-            pylint_exe="pylint"
+        # pylint-3 for newer rpm versions
+        # python3-pylint for older version of rpm (before F26)
+        # pylint when installed from pip, not rpm
+        pylint_paths = ("/usr/bin/pylint-3", "/usr/bin/python3-pylint", "pylint")
+        pylint_exe = next((i for i in pylint_paths if os.path.exists(i)), None)
+
         proc = subprocess.Popen([pylint_exe] + self._pylint_args + args + [filename],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = proc.communicate()


### PR DESCRIPTION
In Fedora 26 the `python3-pylint` was renamed to `pylint-3.6` and `pylint-3` symlink was created to point to this `pylint-3.*` executable.
Fix this by looking for the `pylint-3` on the first place and then for `python3-pylint` to be backward compatible.

---------------------------------------
Right now you shouldn't merge this PR because `pylint-3` symlink is missing in rpm. We are waiting on this https://bodhi.fedoraproject.org/updates/FEDORA-2017-8c8f407428 .

However please merge this ASAP (of course after bodhi update); it is a test blocker for rawhide and fedora 26 for Anaconda right now.