### PR TITLE
Use new astroid class names

### DIFF
--- a/pocketlint/checkers/environ.py
+++ b/pocketlint/checkers/environ.py
@@ -68,11 +68,11 @@ class EnvironChecker(BaseChecker):
         # Check both for uses of os.putenv and os.setenv and modifying calls
         # to the os.environ object, such as os.environ.update
 
-        if not isinstance(node, astroid.CallFunc):
+        if not isinstance(node, astroid.Call):
             return
 
         function_node = safe_infer(node.func)
-        if not isinstance(function_node, (astroid.Function, astroid.BoundMethod)):
+        if not isinstance(function_node, (astroid.FunctionDef, astroid.BoundMethod)):
             return
 
         # If the function is from the os or posix modules, look for calls that

--- a/pocketlint/checkers/intl.py
+++ b/pocketlint/checkers/intl.py
@@ -72,7 +72,7 @@ class IntlChecker(BaseChecker):
 
         curr = node
         while curr.parent:
-            if isinstance(curr.parent, astroid.CallFunc) and getattr(curr.parent.func, "name", "") in translationMethods:
+            if isinstance(curr.parent, astroid.Call) and getattr(curr.parent.func, "name", "") in translationMethods:
                 self.add_message("W9901", node=node)
                 break
 
@@ -100,7 +100,7 @@ class IntlLoggingChecker(LoggingChecker):
 
     @check_messages('translated-log')
     def visit_call(self, node):
-        if len(node.args) >= 1 and isinstance(node.args[0], astroid.CallFunc) and \
+        if len(node.args) >= 1 and isinstance(node.args[0], astroid.Call) and \
                 getattr(node.args[0].func, "name", "") in translationMethods:
             for formatstr in _get_message_strings(node.args[0]):
                 # Both the node and the args need to be copied so we don't replace args
@@ -134,7 +134,7 @@ class IntlStringFormatChecker(StringFormatChecker):
         if node.op != '%':
             return
 
-        if isinstance(node.left, astroid.CallFunc) and getattr(node.left.func, "name", "") in translationMethods:
+        if isinstance(node.left, astroid.Call) and getattr(node.left.func, "name", "") in translationMethods:
             for formatstr in _get_message_strings(node.left):
                 # Create a copy of the node with just the message string as the format
                 copynode = copy(node)

--- a/pocketlint/checkers/markup.py
+++ b/pocketlint/checkers/markup.py
@@ -94,19 +94,19 @@ class MarkupChecker(BaseChecker):
 
         # Check whether the right side of the % operation is escaped
         if formatOp:
-            if isinstance(formatOp.right, astroid.CallFunc):
+            if isinstance(formatOp.right, astroid.Call):
                 if getattr(formatOp.right.func, "name", "") not in escapeMethods:
                     self.add_message("W9922", node=formatOp.right)
             # If a tuple, each item in the tuple must be escaped
             elif isinstance(formatOp.right, astroid.Tuple):
                 for elt in formatOp.right.elts:
-                    if not isinstance(elt, astroid.CallFunc) or\
+                    if not isinstance(elt, astroid.Call) or\
                             getattr(elt.func, "name", "") not in escapeMethods:
                         self.add_message("W9922", node=elt)
             # If a dictionary, each value must be escaped
             elif isinstance(formatOp.right, astroid.Dict):
                 for item in formatOp.right.items:
-                    if not isinstance(item[1], astroid.CallFunc) or\
+                    if not isinstance(item[1], astroid.Call) or\
                             getattr(item[1].func, "name", "") not in escapeMethods:
                         self.add_message("W9922", node=item[1])
             else:

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -114,7 +114,7 @@ class PointlessData(object):
 class PointlessFunctionDefinition(PointlessData):
     """ Looking for pointless function definitions. """
 
-    _DEF_CLASS = astroid.Function
+    _DEF_CLASS = astroid.FunctionDef
     message_id = "W9952"
 
     @classmethod
@@ -141,7 +141,7 @@ class PointlessAssignment(PointlessData):
     message_id = "W9951"
 
     _VALUE_CLASSES = (
-        astroid.CallFunc,
+        astroid.Call,
         astroid.Const,
         astroid.Dict,
         astroid.List,
@@ -166,7 +166,7 @@ class PointlessAssignment(PointlessData):
         if isinstance(node, astroid.Dict):
             return len(node.items) == len(other.items) and \
                all(cls.check_equal(n, o) for (n, o) in zip(sorted(node.items), sorted(other.items)))
-        if isinstance(node, astroid.CallFunc):
+        if isinstance(node, astroid.Call):
             if type(node.func) != type(other.func):
                 return False
 

--- a/pocketlint/checkers/preconf.py
+++ b/pocketlint/checkers/preconf.py
@@ -36,7 +36,7 @@ class PreconfChecker(BaseChecker):
     @check_messages("bad-preconf-access")
     def visit_getattr(self, node):
         if node.attrname == "preconf":
-            if not isinstance(node.scope(), astroid.Function) or not node.scope().name == "_resetYum":
+            if not isinstance(node.scope(), astroid.FunctionDef) or not node.scope().name == "_resetYum":
                 self.add_message("W9910", node=node)
 
 def register(linter):


### PR DESCRIPTION
Those are available with 1.6.x and 2.x as well, but the old one were removed from 2.x.

Fixes https://github.com/rhinstaller/pocketlint/issues/21