### PR TITLE
Use new astroid API

### DIFF
--- a/pocketlint/checkers/environ.py
+++ b/pocketlint/checkers/environ.py
@@ -37,7 +37,7 @@ class EnvironChecker(BaseChecker):
     def _is_environ(self, node):
         # Guess whether a node being modified is os.environ
 
-        if isinstance(node, astroid.Getattr):
+        if isinstance(node, astroid.Attribute):
             if node.attrname == "environ":
                 expr_node = safe_infer(node.expr)
                 if isinstance(expr_node, astroid.Module) and expr_node.name == "os":

--- a/pocketlint/checkers/intl.py
+++ b/pocketlint/checkers/intl.py
@@ -82,7 +82,7 @@ class IntlChecker(BaseChecker):
     def visit_call(self, node):
         # The first test skips internal functions like getattr.
         if isinstance(node.func, astroid.Name) and node.func.name == "_":
-            if isinstance(node.scope(), astroid.Module) or isinstance(node.scope(), astroid.Class):
+            if isinstance(node.scope(), astroid.Module) or isinstance(node.scope(), astroid.ClassDef):
                 self.add_message("W9902", node=node)
 
 # Extend LoggingChecker to check translated logging strings

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -170,7 +170,7 @@ class PointlessAssignment(PointlessData):
             if type(node.func) != type(other.func):
                 return False
 
-            if isinstance(node.func, astroid.Getattr):
+            if isinstance(node.func, astroid.Attribute):
                 if node.func.attrname != other.func.attrname or \
                    type(node.func.expr) != type(other.func.expr) or \
                    node.func.expr.name != other.func.expr.name:


### PR DESCRIPTION
Some old API was removed in Astroid 2.0.0.
More changes, not covered in b0b0d7fb0c904ad02ee58ef83588af71addfe69b

Fixes #21 