### PR TITLE
Ignore config file line printed by pylint

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -292,7 +292,7 @@ class PocketLinter(object):
 
         for line in lines:
             # This is not an error message.  Ignore it.
-            if line.startswith("*****") or not line.strip():
+            if line.startswith("*****") or line.startswith("Using config file") or not line.strip():
                 continue
             else:
                 validError = True


### PR DESCRIPTION
Since 1.9 pylint started printing location of config file to
stderr and pocketlint thinks this is a pylint warning/error. This
behaviour was fixed in pylint 2.0.