### PR TITLE
Fix setup required packages

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -26,7 +26,6 @@ import concurrent.futures
 import os
 import re
 import shutil
-import six
 import subprocess
 import sys
 import tempfile
@@ -211,16 +210,11 @@ class PocketLinter(object):
 
     @property
     def _pylint_executable(self):
-        # pylint-3/pylint-2 for newer rpm versions
-        # python3-pylint/python2-pylint for older version of rpm (before F26)
-        # python-pylint for python2 version on RHEL/CentOS 7
+        # pylint-3 for newer rpm versions
+        # python3-pylint for older version of rpm (before F26)
         # pylint when installed from pip, not rpm
         # pylint3 on Debian
-        if six.PY3:
-            pylint_binaries = ("pylint-3", "python3-pylint", "pylint3", "pylint")
-        else:
-            pylint_binaries = ("pylint-2", "python2-pylint", "python-pylint",
-                               "pylint")
+        pylint_binaries = ("pylint-3", "python3-pylint", "pylint3", "pylint")
         return next((i for i in pylint_binaries if self._command_exists(i)), None)
 
     @property

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -20,17 +20,13 @@
 #
 
 import abc
-
-from six import add_metaclass
-
 import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
 
-@add_metaclass(abc.ABCMeta)
-class PointlessData(object):
+class PointlessData(object, metaclass=abc.ABCMeta):
 
     _DEF_CLASS = abc.abstractproperty(doc="Class of interesting definitions.")
     message_id = abc.abstractproperty(doc="Pylint message identifier.")

--- a/python-pocketlint.spec
+++ b/python-pocketlint.spec
@@ -35,11 +35,9 @@ Summary: Support for running pylint against projects (Python 3 version)
 
 BuildRequires: python3-devel
 BuildRequires: python3-pylint
-BuildRequires: python3-six
 
 Requires: python3-polib
 Requires: python3-pylint
-Requires: python3-six
 
 %description -n python3-%{srcname}
 Addon pylint modules and configuration settings for checking the validity of

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='pocketlint', version='0.17',
       author='Chris Lumens', author_email='clumens@redhat.com',
       url='https://github.com/rhinstaller/pocketlint',
       license='COPYING',
-      install_requires=['pylint'],
+      install_requires=['pylint', 'polib'],
       long_description=open('README').read(),
       packages=['pocketlint', 'pocketlint.checkers'],
       classifiers=[


### PR DESCRIPTION
Add polib to `setup.py` to have this correctly downloaded by pip.
Remove dependency on `six` package. The `pocketlint` project is `python3` only for some time now so or so.