### PR TITLE
Make bumpver lang independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ rpmlog:
 bumpver:
 	@NEWSUBVER=$$((`echo $(VERSION) |cut -d . -f 2` + 1)) ; \
 	NEWVERSION=`echo $(VERSION).$$NEWSUBVER |cut -d . -f 1,3` ; \
-	DATELINE="* `date "+%a %b %d %Y"` `git config user.name` <`git config user.email`> - $$NEWVERSION-1"  ; \
+	DATELINE="* `LC_ALL=C.UTF-8 date "+%a %b %d %Y"` `git config user.name` <`git config user.email`> - $$NEWVERSION-1"  ; \
 	cl=`grep -n %changelog python-${PKGNAME}.spec |cut -d : -f 1` ; \
 	tail --lines=+$$(($$cl + 1)) python-${PKGNAME}.spec > speclog ; \
 	(head -n $$cl python-${PKGNAME}.spec ; echo "$$DATELINE" ; make --quiet rpmlog 2>/dev/null ; echo ""; cat speclog) > python-${PKGNAME}.spec.new ; \


### PR DESCRIPTION
The date command changes based on the language set on the system which results in invalid changelog. Set the date command to English only.