### PR TITLE
Adapt to the new LoggingChecker class

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -32,6 +32,7 @@ import tempfile
 
 from distutils.version import LooseVersion
 
+
 class PocketLintConfig(object):
     """Configuration object that a project should use to tell pylint how
        to operate.  Instance attributes:
@@ -104,6 +105,7 @@ class PocketLintConfig(object):
         """
         return set()
 
+
 class FalsePositive(object):
     """An object used in filtering out incorrect results from pylint.  Pass in
        a regular expression matching a pylint error message that should be
@@ -114,6 +116,7 @@ class FalsePositive(object):
         self.regex = regex
         self.used = 0
 
+
 class PocketLinter(object):
     """Main class that does the hard work of running pylint on a project.
        Pass an instance of PocketLintConfig to a new instance of this class
@@ -122,7 +125,7 @@ class PocketLinter(object):
 
        from pocketlint import PocketLintConfig, PocketLinter
 
-       classs FooLintConfig(PocketLintConfig):
+       class FooLintConfig(PocketLintConfig):
           ....
 
        if __name__ == "__main__":

--- a/pocketlint/checkers/environ.py
+++ b/pocketlint/checkers/environ.py
@@ -27,6 +27,7 @@ from pylint.interfaces import IAstroidChecker
 
 import os
 
+
 class EnvironChecker(BaseChecker):
     __implements__ = (IAstroidChecker,)
     name = "environ"
@@ -101,6 +102,7 @@ class EnvironChecker(BaseChecker):
 
             if self._is_environ(target.value):
                 self.add_message("environment-modify", node=node)
+
 
 def register(linter):
     """required method to auto register this checker """

--- a/pocketlint/checkers/intl.py
+++ b/pocketlint/checkers/intl.py
@@ -31,6 +31,7 @@ from copy import copy
 
 translationMethods = frozenset(["_", "N_", "P_", "C_", "CN_", "CP_"])
 
+
 # Returns a list of the message strings for a given translation method call
 def _get_message_strings(node):
     msgstrs = []
@@ -53,6 +54,7 @@ def _get_message_strings(node):
             msgstrs.append(node.args[2].value)
 
     return msgstrs
+
 
 class IntlChecker(BaseChecker):
     __implements__ = (IAstroidChecker, )
@@ -84,6 +86,7 @@ class IntlChecker(BaseChecker):
         if isinstance(node.func, astroid.Name) and node.func.name == "_":
             if isinstance(node.scope(), astroid.Module) or isinstance(node.scope(), astroid.ClassDef):
                 self.add_message("W9902", node=node)
+
 
 # Extend LoggingChecker to check translated logging strings
 class IntlLoggingChecker(LoggingChecker):
@@ -117,6 +120,7 @@ class IntlLoggingChecker(LoggingChecker):
         # solution would be when pylint supports inheritance of the existing checkers.
         self.options = ()
 
+
 # Extend StringFormatChecker to check translated format strings
 class IntlStringFormatChecker(StringFormatChecker):
     __implements__ = (IAstroidChecker,)
@@ -139,6 +143,7 @@ class IntlStringFormatChecker(StringFormatChecker):
                 copynode = copy(node)
                 copynode.left = astroid.Const(formatstr)
                 StringFormatChecker.visit_binop(self, copynode)
+
 
 def register(linter):
     """required method to auto register this checker """

--- a/pocketlint/checkers/intl.py
+++ b/pocketlint/checkers/intl.py
@@ -96,8 +96,6 @@ class IntlLoggingChecker(LoggingChecker):
                        logging format messages extended for translated strings")
            }
 
-    options = ()
-
     @check_messages('translated-log')
     def visit_call(self, node):
         if len(node.args) >= 1 and isinstance(node.args[0], astroid.Call) and \
@@ -114,9 +112,10 @@ class IntlLoggingChecker(LoggingChecker):
     def __init__(self, *args, **kwargs):
         LoggingChecker.__init__(self, *args, **kwargs)
 
-        # Just set logging_modules to 'logging', instead of trying to take a parameter
-        # like LoggingChecker
-        self.config.logging_modules = ('logging',)
+        # FIXME: Remove this hack by something what pylint supports.
+        # This hack will avoid crash thanks to the colliding option names. The best
+        # solution would be when pylint supports inheritance of the existing checkers.
+        self.options = ()
 
 # Extend StringFormatChecker to check translated format strings
 class IntlStringFormatChecker(StringFormatChecker):

--- a/pocketlint/checkers/markup.py
+++ b/pocketlint/checkers/markup.py
@@ -35,6 +35,7 @@ escapeMethods = ["escape_markup"]
 i18n_funcs = ["_", "N_", "P_", "C_", "CN_", "CP_"]
 i18n_ctxt_funcs = ["C_", "CN_", "CP_"]
 
+
 class MarkupChecker(BaseChecker):
     __implements__ = (IAstroidChecker,)
     name = "pango-markup"
@@ -111,6 +112,7 @@ class MarkupChecker(BaseChecker):
                         self.add_message("W9922", node=item[1])
             else:
                 self.add_message("W9922", node=formatOp)
+
 
 def register(linter):
     """required method to auto register this checker """

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -26,6 +26,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
 
+
 class PointlessData(object, metaclass=abc.ABCMeta):
 
     _DEF_CLASS = abc.abstractproperty(doc="Class of interesting definitions.")
@@ -107,6 +108,7 @@ class PointlessData(object, metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
+
 class PointlessFunctionDefinition(PointlessData):
     """ Looking for pointless function definitions. """
 
@@ -130,6 +132,7 @@ class PointlessFunctionDefinition(PointlessData):
     @staticmethod
     def _extract_targets(node):
         yield node.name
+
 
 class PointlessAssignment(PointlessData):
 
@@ -191,6 +194,7 @@ class PointlessAssignment(PointlessData):
     def _extract_targets(node):
         for target in node.targets:
             yield target.name
+
 
 class PointlessClassAttributeOverrideChecker(BaseChecker):
     """ If the nearest definition of the class attribute in the MRO assigns
@@ -266,6 +270,7 @@ class PointlessClassAttributeOverrideChecker(BaseChecker):
                         if checker.check_equal(value, match):
                             self.add_message(checker.message_id, node=value, args=(name,a.name))
                         break
+
 
 def register(linter):
     linter.register_checker(PointlessClassAttributeOverrideChecker(linter))

--- a/pocketlint/checkers/preconf.py
+++ b/pocketlint/checkers/preconf.py
@@ -25,6 +25,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from pylint.interfaces import IAstroidChecker
 
+
 class PreconfChecker(BaseChecker):
     __implements__ = (IAstroidChecker, )
     name = "Yum preconf"
@@ -38,6 +39,7 @@ class PreconfChecker(BaseChecker):
         if node.attrname == "preconf":
             if not isinstance(node.scope(), astroid.FunctionDef) or not node.scope().name == "_resetYum":
                 self.add_message("W9910", node=node)
+
 
 def register(linter):
     """required method to auto register this checker """

--- a/pocketlint/pangocheck.py
+++ b/pocketlint/pangocheck.py
@@ -26,6 +26,7 @@ __all__ = ["markup_nodes", "is_markup", "markup_match"]
 # "a" isn't actually pango markup, but GtkLabel uses it
 markup_nodes = ["markup", "a", "b", "big", "i", "s", "span", "sub", "sup", "small", "tt", "u"]
 
+
 # Check to see if a string looks like Pango markup, no validation
 def is_markup(test_string):
     if isinstance(test_string, bytes):
@@ -33,6 +34,7 @@ def is_markup(test_string):
 
     return any(re.search(r'<\s*%s(\s|>)' % node_type, test_string)
             for node_type in markup_nodes)
+
 
 # Verify that the translation of a markup string looks more or less like the original
 def markup_match(orig_markup, xlated_markup):
@@ -67,6 +69,7 @@ def markup_match(orig_markup, xlated_markup):
     attr_list2 = sorted(attr_count2.elements())
 
     return (name_list1 == name_list2) and (attr_list1 == attr_list2)
+
 
 # Check that the markup is needed at all.
 # The input is a parsed ElementTree of the string '<markup>pango markup goes here</markup>'

--- a/pocketlint/translatepo.py
+++ b/pocketlint/translatepo.py
@@ -31,6 +31,7 @@ except ImportError:
     print("You need to install the python-polib package to read translations")
     raise
 
+
 class PODict(object):
     def __init__(self, filename):
         """Create a new dictionary of translations from a po file."""
@@ -59,6 +60,7 @@ class PODict(object):
 
     def get(self, key, context=None):
         return self._dict[context][key]
+
 
 # Return a dictionary of PODict objects for each language in a po directory
 def translate_all(podir):

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -4,6 +4,7 @@ import sys
 
 from pocketlint import PocketLintConfig, PocketLinter
 
+
 class PocketLintPocketLintConfig(PocketLintConfig):
     @property
     def pylintPlugins(self):
@@ -12,6 +13,7 @@ class PocketLintPocketLintConfig(PocketLintConfig):
         # threads are not involved (yet).
         retval.remove("pocketlint.checkers.environ")
         return retval
+
 
 if __name__ == "__main__":
     conf = PocketLintPocketLintConfig()


### PR DESCRIPTION
Pylint version 2.2.0 will ends with exception without this change. The change will set default value for new `logging_format_style` to our `IntlLoggingChecker` class.

This whole thing is required thanks to that we based this class on an existing checker class not on the `BaseChecker`.

This change is required thanks to this commit:

https://github.com/PyCQA/pylint/commit/0dd573faae1ad339c07f789270002f8faf2a3691