### PR TITLE
Fix reading pylint version

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -221,7 +221,7 @@ class PocketLinter(object):
         exc.append("--version")
         proc = subprocess.Popen(exc, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, _stderr) = proc.communicate()
-        pattern = re.compile(r"%s (?P<version>[1-9.]+)" % exc)
+        pattern = re.compile(r".+ (?P<version>[1-9.]+)")
         match = pattern.search(stdout.decode())
         if match:
             return LooseVersion(match.group("version"))


### PR DESCRIPTION
We no longer know name of the pylint binary so just try to get
first number-like part of the version string and hope for the best.