### PR TITLE
Add build dependency on python3-setuptools

### DIFF
--- a/python-pocketlint.spec
+++ b/python-pocketlint.spec
@@ -35,6 +35,7 @@ Summary: Support for running pylint against projects (Python 3 version)
 
 BuildRequires: python3-devel
 BuildRequires: python3-pylint
+BuildRequires: python3-setuptools
 
 Requires: python3-polib
 Requires: python3-pylint


### PR DESCRIPTION
We now get it by depending on python3-devel but this might change
in the future and Fedora Python team asked maintainers to depend
on it directly.