### PR TITLE
spec: Remove Python 2 and make Python 3 non-optional

### DIFF
--- a/python-pocketlint.spec
+++ b/python-pocketlint.spec
@@ -1,18 +1,5 @@
 %global srcname pocketlint
 
-# python2 is not available on RHEL > 7 and not needed on Fedora > 28
-%if 0%{?rhel} > 7 || 0%{?fedora} > 28
-%bcond_with python2
-%else
-%bcond_without python2
-%endif
-
-%if 0%{?fedora} || 0%{?rhel} > 7
-%bcond_without python3
-%else
-%bcond_with python3
-%endif
-
 Name:      python-%{srcname}
 Version:   0.20
 Release:   1%{?dist}
@@ -28,7 +15,6 @@ BuildArch: noarch
 Addon pylint modules and configuration settings for checking the validity of
 Python-based source projects.
 
-%if %{with python3}
 %package -n python3-%{srcname}
 Summary: Support for running pylint against projects (Python 3 version)
 %{?python_provide:%python_provide python3-%{srcname}}
@@ -43,78 +29,23 @@ Requires: python3-pylint
 %description -n python3-%{srcname}
 Addon pylint modules and configuration settings for checking the validity of
 Python-based source projects.
-%endif
-
-%if %{with python2}
-%package -n python2-%{srcname}
-Summary: Support for running pylint against projects (Python 2 version)
-%{?python_provide:%python_provide python2-%{srcname}}
-
-BuildRequires: python2-devel
-BuildRequires: python2-six
-BuildRequires: python2-futures
-
-%if 0%{?fedora} >= 26
-BuildRequires: python2-pylint
-%else
-BuildRequires: pylint
-%endif
-
-Requires: python2-polib
-Requires: python2-six
-Requires: python2-futures
-
-%if 0%{?fedora} >= 26
-Requires: python2-pylint
-%else
-Requires: pylint
-%endif
-
-%description -n python2-%{srcname}
-Addon pylint modules and configuration settings for checking the validity of
-Python-based source projects.
-%endif
 
 %prep
 %autosetup -n %{srcname}-%{version} -p1
 
 %build
-%if %{with python2}
-make PYTHON=%{__python2}
-%endif
-%if %{with python3}
 make PYTHON=%{__python3}
-%endif
 
 %install
-%if %{with python2}
-make DESTDIR=%{buildroot} PYTHON=%{__python2} install
-%endif
-%if %{with python3}
 make DESTDIR=%{buildroot} PYTHON=%{__python3} install
-%endif
 
 %check
-%if %{with python2}
-make PYTHON=%{__python2} check
-%endif
-%if %{with python3}
 make PYTHON=%{__python3} check
-%endif
 
-%if %{with python3}
 %files -n python3-%{srcname}
 %license COPYING
 %{python3_sitelib}/%{srcname}*egg*
 %{python3_sitelib}/%{srcname}/
-%endif
-
-%if %{with python2}
-%files -n python2-%{srcname}
-%license COPYING
-%{python2_sitelib}/%{srcname}*egg*
-%{python2_sitelib}/%{srcname}/
-%endif
 
 %changelog
 * Fri Aug 30 2019 Jiri Konecny <jkonecny@redhat.com> - 0.20-1


### PR DESCRIPTION
Just a simplification of the SPEC file, we stopped building
python2-pocketling in Fedora 28.