### PR TITLE
Specify encoding for open()

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -164,7 +164,7 @@ class PocketLinter(object):
 
             for f in files:
                 try:
-                    with open(root + "/" + f) as fo:
+                    with open(root + "/" + f, encoding='utf-8') as fo:
                         lines = fo.readlines()
                 except UnicodeDecodeError:
                     # If we couldn't open this file, just skip it.  It wasn't
@@ -344,7 +344,7 @@ class PocketLinter(object):
             files = self._files
 
         if self._pylint_log:
-            fo = open("pylint-log", "w")
+            fo = open("pylint-log", "w", encoding='utf-8')
         else:
             fo = None
 

--- a/pocketlint/translatepo.py
+++ b/pocketlint/translatepo.py
@@ -66,7 +66,7 @@ class PODict(object):
 def translate_all(podir):
     podicts = {}
 
-    with open(os.path.join(podir, 'LINGUAS')) as linguas:
+    with open(os.path.join(podir, 'LINGUAS'), encoding='utf-8') as linguas:
         for line in linguas.readlines():
             if re.match(r'^#', line):
                 continue

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='pocketlint', version='0.21',
       url='https://github.com/rhinstaller/pocketlint',
       license='COPYING',
       install_requires=['pylint', 'polib'],
-      long_description=open('README').read(),
+      long_description=open('README', encoding='utf-8').read(),
       packages=['pocketlint', 'pocketlint.checkers'],
       classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
According to PEP 597 using open() is not recommended and pylint
shows a warning for this.