### PR TITLE
Do not use Fedora container to GH checkout action

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,14 +3,12 @@ on: [push, pull_request]
 jobs:
   rawhide:
     runs-on: ubuntu-latest
-    container:
-      image: docker.io/fedora:rawhide
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
 
       - name: Install test dependencies
-        run: dnf install -y python3-pylint make
-
-      - name: Run tests
-        run: make ci
+        run: |
+          podman run --rm -v .:/pocketlint:Z --workdir /pocketlint registry.fedoraproject.org/fedora:rawhide sh -c " \
+          dnf install -y python3-pylint make; \
+          make ci;"


### PR DESCRIPTION
The Fedora container is not able to do GitHub checkout action. We need to use the container only for the test run.