### PR TITLE
Use packaging.version instead of distutils.version

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,5 +10,5 @@ jobs:
       - name: Install test dependencies
         run: |
           podman run --rm -v .:/pocketlint:Z --workdir /pocketlint registry.fedoraproject.org/fedora:rawhide sh -c " \
-          dnf install -y python3-pylint make; \
+          dnf install -y python3-packaging python3-pylint make; \
           make ci;"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .*.swp
 tests/pylint/.pylint.d/
+__pycache__/
+pylint-log

--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 import tempfile
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 class PocketLintConfig(object):
@@ -205,7 +205,7 @@ class PocketLinter(object):
             args += ["--unsafe-load-any-extension=yes"]
 
         # since 1.7 pylint by default prints "score", we need to disable it
-        if self._pylint_version >= LooseVersion("1.7.0"):
+        if self._pylint_version >= Version("1.7.0"):
             args += ["-s", "n"]
 
         return args
@@ -229,9 +229,9 @@ class PocketLinter(object):
         pattern = re.compile(r".+ (?P<version>[1-9.]+)")
         match = pattern.search(stdout.decode())
         if match:
-            return LooseVersion(match.group("version"))
+            return Version(match.group("version"))
         else:
-            return LooseVersion("0")
+            return Version("0")
 
     def _parseArgs(self):
         # Really stupid argument processing - strip off the first argument (that's

--- a/python-pocketlint.spec
+++ b/python-pocketlint.spec
@@ -21,9 +21,11 @@ Summary: Support for running pylint against projects (Python 3 version)
 
 BuildRequires: make
 BuildRequires: python3-devel
+BuildRequires: python3-packaging
 BuildRequires: python3-pylint
 BuildRequires: python3-setuptools
 
+Requires: python3-packaging
 Requires: python3-polib
 Requires: python3-pylint
 


### PR DESCRIPTION
distutils module is deprecated and will be removed in Python 3.12.