### PR TITLE
Fix reading pylint version

### DIFF
--- a/pocketlint/__init__.py
+++ b/pocketlint/__init__.py
@@ -226,7 +226,7 @@ class PocketLinter(object):
         exc.append("--version")
         proc = subprocess.Popen(exc, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, _stderr) = proc.communicate()
-        pattern = re.compile(r".+ (?P<version>[1-9.]+)")
+        pattern = re.compile(r".+ (?P<version>[0-9.]+)")
         match = pattern.search(stdout.decode())
         if match:
             return Version(match.group("version"))


### PR DESCRIPTION
The regex pattern incorrectly parses the latest version 2.14.0 and
the packaging version module doesn't like version "2.14.".