### PR TITLE
A couple updates for pylint 3.0

### DIFF
--- a/pocketlint/checkers/environ.py
+++ b/pocketlint/checkers/environ.py
@@ -22,7 +22,7 @@
 import astroid
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages, safe_infer
+from pylint.checkers.utils import only_required_for_messages, safe_infer
 from pylint.interfaces import IAstroidChecker
 
 import os
@@ -51,7 +51,7 @@ class EnvironChecker(BaseChecker):
 
         return False
 
-    @check_messages("environment-modify")
+    @only_required_for_messages("environment-modify")
     def visit_assign(self, node):
         if not isinstance(node, astroid.Assign):
             return
@@ -64,7 +64,7 @@ class EnvironChecker(BaseChecker):
             if self._is_environ(target.value):
                 self.add_message("environment-modify", node=node)
 
-    @check_messages("environment-modify")
+    @only_required_for_messages("environment-modify")
     def visit_call(self, node):
         # Check both for uses of os.putenv and os.setenv and modifying calls
         # to the os.environ object, such as os.environ.update
@@ -90,7 +90,7 @@ class EnvironChecker(BaseChecker):
                 function_node.name in ("clear", "pop", "popitem", "setdefault", "update"):
             self.add_message("environment-modify", node=node)
 
-    @check_messages("environment-modify")
+    @only_required_for_messages("environment-modify")
     def visit_delete(self, node):
         if not isinstance(node, astroid.Delete):
             return

--- a/pocketlint/checkers/environ.py
+++ b/pocketlint/checkers/environ.py
@@ -23,13 +23,11 @@ import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages, safe_infer
-from pylint.interfaces import IAstroidChecker
 
 import os
 
 
 class EnvironChecker(BaseChecker):
-    __implements__ = (IAstroidChecker,)
     name = "environ"
     msgs = {"W9940" : ("Found potentially unsafe modification of environment",
                        "environment-modify",

--- a/pocketlint/checkers/intl.py
+++ b/pocketlint/checkers/intl.py
@@ -24,7 +24,7 @@ import astroid
 from pylint.checkers import BaseChecker
 from pylint.checkers.strings import StringFormatChecker
 from pylint.checkers.logging import LoggingChecker
-from pylint.checkers.utils import check_messages
+from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import IAstroidChecker
 
 from copy import copy
@@ -67,7 +67,7 @@ class IntlChecker(BaseChecker):
                       "Calling _ at the module or class level results in translations to the wrong language")
            }
 
-    @check_messages("found-percent-in-_")
+    @only_required_for_messages("found-percent-in-_")
     def visit_binop(self, node):
         if node.op != "%":
             return
@@ -80,7 +80,7 @@ class IntlChecker(BaseChecker):
 
             curr = curr.parent
 
-    @check_messages("found-_-in-module-class")
+    @only_required_for_messages("found-_-in-module-class")
     def visit_call(self, node):
         # The first test skips internal functions like getattr.
         if isinstance(node.func, astroid.Name) and node.func.name == "_":
@@ -99,7 +99,7 @@ class IntlLoggingChecker(LoggingChecker):
                        logging format messages extended for translated strings")
            }
 
-    @check_messages('translated-log')
+    @only_required_for_messages('translated-log')
     def visit_call(self, node):
         if len(node.args) >= 1 and isinstance(node.args[0], astroid.Call) and \
                 getattr(node.args[0].func, "name", "") in translationMethods:
@@ -132,7 +132,7 @@ class IntlStringFormatChecker(StringFormatChecker):
                        string format messages extended for translated strings")
            }
 
-    @check_messages('translated-format')
+    @only_required_for_messages('translated-format')
     def visit_binop(self, node):
         if node.op != '%':
             return

--- a/pocketlint/checkers/intl.py
+++ b/pocketlint/checkers/intl.py
@@ -25,7 +25,6 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.strings import StringFormatChecker
 from pylint.checkers.logging import LoggingChecker
 from pylint.checkers.utils import only_required_for_messages
-from pylint.interfaces import IAstroidChecker
 
 from copy import copy
 
@@ -57,7 +56,6 @@ def _get_message_strings(node):
 
 
 class IntlChecker(BaseChecker):
-    __implements__ = (IAstroidChecker, )
     name = "internationalization"
     msgs = {"W9901": ("Found % in a call to a _() method",
                       "found-percent-in-_",
@@ -90,8 +88,6 @@ class IntlChecker(BaseChecker):
 
 # Extend LoggingChecker to check translated logging strings
 class IntlLoggingChecker(LoggingChecker):
-    __implements__ = (IAstroidChecker,)
-
     name = 'intl-logging'
     msgs = {'W9903': ("Fake message for translated E/W120* checks",
                       "translated-log",
@@ -123,8 +119,6 @@ class IntlLoggingChecker(LoggingChecker):
 
 # Extend StringFormatChecker to check translated format strings
 class IntlStringFormatChecker(StringFormatChecker):
-    __implements__ = (IAstroidChecker,)
-
     name = 'intl-string'
     msgs = {'W9904': ("Fake message for translated E/W130* checks",
                       "translated-format",

--- a/pocketlint/checkers/markup.py
+++ b/pocketlint/checkers/markup.py
@@ -23,7 +23,6 @@ import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
-from pylint.interfaces import IAstroidChecker
 
 import xml.etree.ElementTree as ET
 
@@ -37,7 +36,6 @@ i18n_ctxt_funcs = ["C_", "CN_", "CP_"]
 
 
 class MarkupChecker(BaseChecker):
-    __implements__ = (IAstroidChecker,)
     name = "pango-markup"
     msgs = {"W9920" : ("Found invalid pango markup",
                        "invalid-markup",

--- a/pocketlint/checkers/markup.py
+++ b/pocketlint/checkers/markup.py
@@ -22,7 +22,7 @@
 import astroid
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
+from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import IAstroidChecker
 
 import xml.etree.ElementTree as ET
@@ -73,7 +73,7 @@ class MarkupChecker(BaseChecker):
     def __init__(self, linter=None):
         BaseChecker.__init__(self, linter)
 
-    @check_messages("invalid-markup", "invalid-markup-element", "unescaped-markup", "unnecessary-markup")
+    @only_required_for_messages("invalid-markup", "invalid-markup-element", "unescaped-markup", "unnecessary-markup")
     def visit_const(self, node):
         if not isinstance(node.value, (str, bytes)):
             return

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -24,7 +24,6 @@ import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
-from pylint.interfaces import IAstroidChecker
 
 
 class PointlessData(object, metaclass=abc.ABCMeta):
@@ -241,9 +240,6 @@ class PointlessClassAttributeOverrideChecker(BaseChecker):
         The analysis is both incomplete and unsound because it expects that
         assignments will always be made by means of the same syntax.
     """
-
-    __implements__ = (IAstroidChecker,)
-
     name = "pointless class attribute override checker"
     msgs = {
        "W9951":

--- a/pocketlint/checkers/pointless-override.py
+++ b/pocketlint/checkers/pointless-override.py
@@ -23,7 +23,7 @@ import abc
 import astroid
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
+from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import IAstroidChecker
 
 
@@ -260,7 +260,7 @@ class PointlessClassAttributeOverrideChecker(BaseChecker):
        )
     }
 
-    @check_messages("W9951", "W9952")
+    @only_required_for_messages("W9951", "W9952")
     def visit_class(self, node):
         for checker in (PointlessAssignment, PointlessFunctionDefinition):
             for (name, value) in checker.get_data(node):

--- a/pocketlint/checkers/preconf.py
+++ b/pocketlint/checkers/preconf.py
@@ -22,7 +22,7 @@
 import astroid
 
 from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
+from pylint.checkers.utils import only_required_for_messages
 from pylint.interfaces import IAstroidChecker
 
 
@@ -34,7 +34,7 @@ class PreconfChecker(BaseChecker):
                       "Accessing yum.preconf outside of _resetYum will cause tracebacks"),
            }
 
-    @check_messages("bad-preconf-access")
+    @only_required_for_messages("bad-preconf-access")
     def visit_getattr(self, node):
         if node.attrname == "preconf":
             if not isinstance(node.scope(), astroid.FunctionDef) or not node.scope().name == "_resetYum":

--- a/pocketlint/checkers/preconf.py
+++ b/pocketlint/checkers/preconf.py
@@ -23,11 +23,9 @@ import astroid
 
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
-from pylint.interfaces import IAstroidChecker
 
 
 class PreconfChecker(BaseChecker):
-    __implements__ = (IAstroidChecker, )
     name = "Yum preconf"
     msgs = {"W9910": ("Accessing yum.preconf outside of _resetYum",
                       "bad-preconf-access",


### PR DESCRIPTION
A couple of things were deprecated back in pylint 2.14 and removed in pylint 3. These changes should be backwards compatible with pylint 2.14 and later.
