### PR TITLE
Replace deprecated setup.py commands

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,38 @@
+actions:
+  get-current-version:
+    - "python3 ./setup.py --version"
+  create-archive:
+    - "make local"
+    - 'bash -c "ls *.tar*"'
+
+jobs:
+# Fedora builds for the 'master' branch
+- job: copr_build
+  targets:
+    - fedora-all
+  trigger: pull_request
+  branch: master
+
+# Downstream builds
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - fedora-all
+
+- job: koji_build
+  trigger: commit
+  dist_git_branches:
+    - fedora-all
+
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-branched
+
+srpm_build_deps:
+ - make
+ - python3-devel
+ - python3-setuptools
+ - python3-build
+
+downstream_package_name: python-pocketlint

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	$(PYTHON) setup.py -q clean --all
 
 install:
-	$(PYTHON) setup.py install --root=$(DESTDIR) --skip-build
+	$(PYTHON) -m pip install . --root=$(DESTDIR) --no-deps --no-build-isolation
 
 tag:
 	git tag -a -m "Tag as $(VERSION)" -f $(VERSION)
@@ -29,9 +29,9 @@ archive: check tag
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 
 release-pypi:
-	if ! $(PYTHON) setup.py sdist bdist_wheel; then \
+	if ! $(PYTHON) -m build --sdist --wheel; then \
 		echo ""; \
-		echo Distribution package build failed! Please verify that you have \'python3-wheel\' and \'python3-setuptools\' installed. >&2; \
+		echo Distribution package build failed! Please verify that you have \'python3-build\' and \'python3-setuptools\' installed. >&2; \
 		exit 1; \
 	fi
 	if ! $(PYTHON) -m twine upload dist/*; then \
@@ -44,8 +44,8 @@ local:
 	@rm -rf $(PKGNAME)-$(VERSION).tar.gz
 	@rm -rf /tmp/$(PKGNAME)-$(VERSION) /tmp/$(PKGNAME)
 	@dir=$$PWD; cp -a $$dir /tmp/$(PKGNAME)-$(VERSION)
-	@cd /tmp/$(PKGNAME)-$(VERSION) ; $(PYTHON) setup.py -q sdist
-	@cp /tmp/$(PKGNAME)-$(VERSION)/dist/$(PKGNAME)-$(VERSION).tar.gz .
+	@cd /tmp/$(PKGNAME)-$(VERSION) ; $(PYTHON) -m build --sdist --outdir .
+	@cp /tmp/$(PKGNAME)-$(VERSION)/$(PKGNAME)-$(VERSION).tar.gz .
 	@rm -rf /tmp/$(PKGNAME)-$(VERSION)
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ bumpver:
 	(head -n $$cl python-${PKGNAME}.spec ; echo "$$DATELINE" ; make --quiet rpmlog 2>/dev/null ; echo ""; cat speclog) > python-${PKGNAME}.spec.new ; \
 	mv python-${PKGNAME}.spec.new python-${PKGNAME}.spec ; rm -f speclog ; \
 	sed -i "s/Version:   $(VERSION)/Version:   $$NEWVERSION/" python-${PKGNAME}.spec ; \
-	sed -i "s/version='$(VERSION)'/version='$$NEWVERSION'/" setup.py
+	sed -i "s/version = \"$(VERSION)\"/version = \"$$NEWVERSION\"/" pyproject.toml
 
 ci:
 	PYTHONPATH=. tests/pylint/runpylint.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pocketlint"
+version = "0.25"
+description = "Support for running pylint against projects"
+readme = "README"
+license = {file = "COPYING"}
+dependencies = ["pylint", "polib", "packaging"]
+authors = [
+  {name = "Chris Lumens", email = "clumens@redhat.com"}
+]
+maintainers = [
+  {name = "Jiri Konecny", email = "jkonecny@redhat.com"},
+  {name = "Vojtech Trefny", email = "vtrefny@redhat.com"}
+]
+classifiers = [
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Testing",
+]
+
+[project.urls]
+source = "https://github.com/rhinstaller/pocketlint"
+
+[tool.setuptools]
+packages = ["pocketlint", "pocketlint.checkers"]

--- a/python-pocketlint.spec
+++ b/python-pocketlint.spec
@@ -21,9 +21,7 @@ Summary: Support for running pylint against projects (Python 3 version)
 
 BuildRequires: make
 BuildRequires: python3-devel
-BuildRequires: python3-packaging
 BuildRequires: python3-pylint
-BuildRequires: python3-setuptools
 
 Requires: python3-packaging
 Requires: python3-polib
@@ -36,18 +34,21 @@ Python-based source projects.
 %prep
 %autosetup -n %{srcname}-%{version} -p1
 
+%generate_buildrequires
+%pyproject_buildrequires
+
 %build
-make PYTHON=%{__python3}
+%pyproject_wheel
 
 %install
-make DESTDIR=%{buildroot} PYTHON=%{__python3} install
+%pyproject_install
 
 %check
 make PYTHON=%{__python3} check
 
 %files -n python3-%{srcname}
 %license COPYING
-%{python3_sitelib}/%{srcname}*egg*
+%{python3_sitelib}/%{srcname}*dist-info
 %{python3_sitelib}/%{srcname}/
 
 %changelog

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,4 @@
 
 from setuptools import setup
 
-setup(name='pocketlint', version='0.25',
-      description='Support for running pylint against projects',
-      author='Chris Lumens', author_email='clumens@redhat.com',
-      url='https://github.com/rhinstaller/pocketlint',
-      license='COPYING',
-      install_requires=['pylint', 'polib', 'packaging'],
-      long_description=open('README', encoding='utf-8').read(),
-      packages=['pocketlint', 'pocketlint.checkers'],
-      classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: GNU General Public License (GPL)",
-        "Operating System :: OS Independent",
-        "Topic :: Software Development :: Testing",
-      ],
-      )
+setup()


### PR DESCRIPTION
`setup.py install` and `setup.py sdist` (and few other) commands are now deprecated and will be removed soon. I also decided to move from `setup.py` to `pyproject.toml` (keeping `setup.py` for backwards compatibility) and added packit configuration for more testing and release automation.